### PR TITLE
【量子シミュレーション和訳】公開ページ上でのバグ修正

### DIFF
--- a/src/courses/utility-scale-quantum-computing/quantum-simulation-ja.ipynb
+++ b/src/courses/utility-scale-quantum-computing/quantum-simulation-ja.ipynb
@@ -11,7 +11,7 @@
         "<Admonition type=\"note\">\n",
         "  Yukio Kawashima (May 30, 2024)　翻訳：Hotaka Hayashi (August 19, 2025)\n",
         "\n",
-        "  元の講義の[PDFのダウンロードはこちらから](https://ibm.box.com/s/kzzsmxhw38vph1ioohczaet53euwi310)。 \n",
+        "  元の講義の[PDFのダウンロードはこちらから](https://github.com/quantum-tokyo/introduction/tree/main/src/courses/utility-scale-quantum-computing)。 \n",
         "\n",
         "  *QPU上の推定ランタイム：7秒*\n",
         "</Admonition>"


### PR DESCRIPTION
以下の公開ページ上で数式の表記がおかしいところがあったので、それを修正しました。
数式表示で、VSCodeと仕様が違うところがあるようです。
https://quantum-tokyo.github.io/introduction/courses/utility-scale-quantum-computing/quantum-simulation-ja.html